### PR TITLE
fix: MatchSeed returns `nether` not `bastion`

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,27 +496,27 @@
                     <tr>
                       <td>id</td>
                       <td><code>String?</code></td>
-                      <td>Seed id if it's ranked filtered seed. it's not real seed number of the seed. it will be <code>null</code> if seed is not filtered.</td>
+                      <td>Seed id if it's a ranked filtered seed. This is not the seed number. It is <code>null</code> if the seed is not filtered.</td>
                     </tr>
                     <tr>
                       <td>overworld</td>
                       <td><code>String?</code></td>
-                      <td>Overworld structure type of the seed. it will be <code>null</code> if seed is not filtered.</td>
+                      <td>Overworld structure type of the seed. It is <code>null</code> if the seed is not filtered.</td>
                     </tr>
                     <tr>
-                      <td>bastion</td>
+                      <td>nether</td>
                       <td><code>String?</code></td>
-                      <td>Bastion remnants type of the seed. it will be <code>null</code> if seed is not filtered.</td>
+                      <td>Bastion remnants type of the seed. It is <code>null</code> if the seed is not filtered.</td>
                     </tr>
                     <tr>
                       <td>endTowers</td>
                       <td><code>Integer[]</code></td>
-                      <td>The <a href="./assets/img/endTowers.png" target="_blank">zero related tower</a> heights of in The End dimension. it will be empty array if seed is not filtered.</td>
+                      <td>The <a href="./assets/img/endTowers.png" target="_blank">zero related tower</a> heights of in The End dimension. It is an empty array if the seed is not filtered.</td>
                     </tr>
                     <tr>
                       <td>variations</td>
                       <td><code>String[]</code></td>
-                      <td>Noticable variations of the seed. it will be empty array if seed is not filtered.</td>
+                      <td>Noticeable variations of the seed. It is an empty array if the seed is not filtered.</td>
                     </tr>
                   </tbody>
                 </table>


### PR DESCRIPTION
This fixes the `MatchSeed` type, which currently indicates it returning `bastion`, when it returns `nether`.

This also cleans up some of the text in this section.