### PR TITLE
fix: ambiguous descriptions for eloRank

### DIFF
--- a/assets/scripts/responses.js
+++ b/assets/scripts/responses.js
@@ -47,7 +47,7 @@ const endpoints = {
             {
                 name: 'eloRank',
                 type: 'Integer?',
-                description: 'Current season rank'
+                description: 'Current season leaderboard rank'
             },
             {
                 name: 'country',
@@ -117,7 +117,7 @@ const endpoints = {
             {
                 name: 'seasonResult.last.eloRank',
                 type: 'Integer?',
-                description: 'Current Elo rank this season'
+                description: 'Current leaderboard rank this season'
             },
             {
                 name: 'seasonResult.last.phasePoint',
@@ -147,7 +147,7 @@ const endpoints = {
             {
                 name: 'seasonResult.phases[].eloRank',
                 type: 'Integer',
-                description: 'Elo rank at phase end'
+                description: 'Leaderboard rank at phase end'
             },
             {
                 name: 'seasonResult.phases[].point',
@@ -375,7 +375,7 @@ const endpoints = {
             {
                 name: 'eloRank',
                 type: 'Integer?',
-                description: 'Current season rank'
+                description: 'Current season leaderboard rank'
             },
             {
                 name: 'country',
@@ -390,7 +390,7 @@ const endpoints = {
             {
                 name: 'seasonResults.{season}.last.eloRank',
                 type: 'Integer?',
-                description: 'Current Elo rank this season'
+                description: 'Current leaderboard rank this season'
             },
             {
                 name: 'seasonResults.{season}.last.phasePoint',
@@ -420,7 +420,7 @@ const endpoints = {
             {
                 name: 'seasonResults.{season}.phases[].eloRank',
                 type: 'Integer',
-                description: 'Elo rank at phase end'
+                description: 'Leaderboard rank at phase end'
             },
             {
                 name: 'seasonResults.{season}.phases[].point',
@@ -668,7 +668,7 @@ const endpoints = {
             {
                 name: 'users[].seasonResult.eloRank',
                 type: 'Integer',
-                description: 'Final Elo rank of player in target season'
+                description: 'Final leaderboard rank of player in target season'
             },
             {
                 name: 'users[].seasonResult.phasePoint',
@@ -730,7 +730,7 @@ const endpoints = {
             {
                 name: 'users[].seasonResult.eloRank',
                 type: 'Integer',
-                description: 'Final Elo rank of player in target season'
+                description: 'Final leaderboard rank of player in target season'
             },
             {
                 name: 'users[].seasonResult.phasePoint',

--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
                     <tr>
                       <td>eloRank</td>
                       <td><code>Integer?</code></td>
-                      <td>User's Elo rank</td>
+                      <td>User's leaderboard rank. It is <code>null</code> if the user hasn't finished placement matches.</td>
                     </tr>
                     <tr>
                       <td>country</td>


### PR DESCRIPTION
I got confused thinking `eloRank` was an integer flag for the different ranks (e.g. Coal II, Diamond I, Netherite), when it never states `eloRank` is actually _leaderboard_ rank. 

I hope it's obvious that the leaderboard is based off elo, so it should be fiiine