### PR TITLE
Fixed incorrect datatype for MatchInfo id

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
                   <tbody>
                     <tr>
                       <td>id</td>
-                      <td><code>String</code></td>
+                      <td><code>Integer</code></td>
                       <td></td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Id field of MatchInfo object is currently listed as a String but should be an Integer.
This is correctly listed in the [openapi.yaml](https://github.com/MCSR-Ranked/api-docs/blob/88321024440d5ffd61b730f823716739b97318da/openapi.yaml#L1027).