### PR TITLE
fix: update wikipedia ISO 3166-1 alpha-2 link

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
                     <tr>
                       <td>country</td>
                       <td><code>String?</code></td>
-                      <td>User's country code in lowercased <a href="https://en.wikipedia.org/wiki/ISO_3166-1" target="_blank">ISO 3166-1 alpha-2</a> format.</td>
+                      <td>User's country code in lowercased <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2" target="_blank">ISO 3166-1 alpha-2</a> format.</td>
                     </tr>
                   </tbody>
                 </table>


### PR DESCRIPTION
change link from https://en.wikipedia.org/wiki/ISO_3166-1 to https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2, just more specific